### PR TITLE
Add support for Peercoin P2PKH address

### DIFF
--- a/btcpy/constants.py
+++ b/btcpy/constants.py
@@ -5,6 +5,7 @@ class Constants(object):
 
     _lookup = {'base58.prefixes': {'P': ('p2pkh', 'mainnet'),
                                    'm': ('p2pkh', 'testnet'),
+                                   'n': ('p2pkh', 'testnet'),
                                    'p': ('p2sh', 'mainnet')},
                'base58.raw_prefixes': {('mainnet', 'p2pkh'): bytearray(b'\x37'),
                                        ('testnet', 'p2pkh'): bytearray(b'\x6f'),

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -862,6 +862,7 @@ class TestPeercoinAddress(unittest.TestCase):
         self.good_addresses = {
             ('mainnet', P2pkhAddress, 'PAdonateFczhZuKLkKHozrcyMJW7Y6TKvw',),
             ('testnet', P2pkhAddress, 'mj46gUeZgeD9ufU7Fvz2dWqaX6Nswtbpba',),
+            ('testnet', P2pkhAddress, 'n12h8P5LrVXozfhEQEqg8SFUmVKtphBetj',),
             ('mainnet', P2shAddress, 'p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK',),
         }
         self.bad_addresses = {


### PR DESCRIPTION
Because Peercoin Testnet addresses can also start with 'n' :)