### PR TITLE
Network namedtuple constants

### DIFF
--- a/btcpy/constants.py
+++ b/btcpy/constants.py
@@ -1,30 +1,96 @@
+from collections import namedtuple
 from decimal import Decimal
 
 
-class Constants(object):
+Constants = namedtuple('Constants', [
+    'name',
+    'base58_prefixes',
+    'base58_raw_prefixes',
+    'bech32_hrp',
+    'bech32_net',
+    'xkeys_prefix',
+    'xpub_version',
+    'xprv_version',
+    'wif_prefix',
+    'decimals',
+])
 
-    _lookup = {'base58.prefixes': {'P': ('p2pkh', 'mainnet'),
-                                   'm': ('p2pkh', 'testnet'),
-                                   'n': ('p2pkh', 'testnet'),
-                                   'p': ('p2sh', 'mainnet')},
-               'base58.raw_prefixes': {('mainnet', 'p2pkh'): bytearray(b'\x37'),
-                                       ('testnet', 'p2pkh'): bytearray(b'\x6f'),
-                                       ('mainnet', 'p2sh'): bytearray(b'\x75'),
-                                       ('testnet', 'p2sh'): bytearray(b'\xc4')},
-               'bech32.net_to_hrp': {'mainnet': 'bc',
-                                     'testnet': 'tb'},
-               'bech32.hrp_to_net': {'bc': 'mainnet',
-                                     'tb': 'testnet'},
-               'xkeys.prefixes': {'mainnet': 'x', 'testnet': 't'},
-               'xpub.version': {'mainnet': b'\x04\x88\xb2\x1e', 'testnet': b'\x04\x35\x87\xcf'},
-               'xprv.version': {'mainnet': b'\x04\x88\xad\xe4', 'testnet': b'\x04\x35\x83\x94'},
-               'wif.prefixes': {'mainnet': 0xb7, 'testnet': 0xef},
-               'decimals': Decimal('1e6')
-               }
 
-    @staticmethod
-    def get(key):
-        try:
-            return Constants._lookup[key]
-        except KeyError:
-            raise ValueError('Unknown constant: {}'.format(key))
+BitcoinMainnet = Constants(
+    name='BitcoinMainnet',
+    base58_prefixes={
+        '1': 'p2pkh',
+        '3': 'p2sh',
+    },
+    base58_raw_prefixes={
+        'p2pkh': bytearray(b'\x00'),
+        'p2sh': bytearray(b'\x05'),
+    },
+    bech32_hrp='bc',
+    bech32_net='mainnet',
+    xkeys_prefix='x',
+    xpub_version=b'\x04\x88\xb2\x1e',
+    xprv_version=b'\x04\x88\xad\xe4',
+    wif_prefix=0x80,
+    decimals=Decimal('1e8'),
+)
+
+
+BitcoinTestnet = Constants(
+    name='BitcoinTestnet',
+    base58_prefixes={
+        'm': 'p2pkh',
+        'n': 'p2pkh',
+        '2': 'p2sh',
+    },
+    base58_raw_prefixes={
+        'p2pkh': bytearray(b'\x6f'),
+        'p2sh': bytearray(b'\xc4'),
+    },
+    bech32_hrp='tb',
+    bech32_net='testnet',
+    xkeys_prefix='t',
+    xpub_version=b'\x04\x35\x87\xcf',
+    xprv_version=b'\x04\x35\x83\x94',
+    wif_prefix=0xef,
+    decimals=Decimal('1e8'),
+)
+
+PeercoinMainnet = Constants(
+    name='PeercoinMainnet',
+    base58_prefixes={
+        'P': 'p2pkh',
+        'p': 'p2sh',
+    },
+    base58_raw_prefixes={
+        'p2pkh': bytearray(b'\x37'),
+        'p2sh': bytearray(b'\x75'),
+    },
+    bech32_hrp='bc',
+    bech32_net='mainnet',
+    xkeys_prefix='x',
+    xpub_version=b'\x04\x88\xb2\x1e',
+    xprv_version=b'\x04\x88\xad\xe4',
+    wif_prefix=0xb7,
+    decimals=Decimal('1e6'),
+)
+
+
+PeercoinTestnet = Constants(
+    name='PeercoinTestnet',
+    base58_prefixes={
+        'm': 'p2pkh',
+        'n': 'p2pkh',
+    },
+    base58_raw_prefixes={
+        'p2pkh': bytearray(b'\x6f'),
+        'p2sh': bytearray(b'\xc4'),
+    },
+    bech32_hrp='tb',
+    bech32_net='testnet',
+    xkeys_prefix='t',
+    xpub_version=b'\x04\x35\x87\xcf',
+    xprv_version=b'\x04\x35\x83\x94',
+    wif_prefix=0xef,
+    decimals=Decimal('1e6'),
+)

--- a/btcpy/setup.py
+++ b/btcpy/setup.py
@@ -11,10 +11,21 @@
 
 from functools import wraps
 
-networks = {'mainnet', 'testnet', 'regtest'}
+from btcpy.constants import (
+    BitcoinMainnet,
+    BitcoinTestnet,
+    PeercoinMainnet,
+    PeercoinTestnet,
+)
 
-MAINNET = None
-NETNAME = None
+
+NETWORKS = (
+    BitcoinMainnet,
+    BitcoinTestnet,
+    PeercoinMainnet,
+    PeercoinTestnet,
+)
+NETWORK = None
 STRICT = None
 
 
@@ -27,29 +38,27 @@ def strictness(func):
     return wrapper
 
 
-def setup(network='mainnet', strict=True, force=False):
-    global MAINNET, NETNAME, STRICT
+def setup(network=BitcoinMainnet, strict=True, force=False):
+    global NETWORK, STRICT
 
     prev_state = get_state()
 
-    if (MAINNET is not None and NETNAME != network) or (STRICT is not None and strict != is_strict()):
+    if (NETWORK is not None and NETWORK != network) or (STRICT is not None and strict != is_strict()):
         if not force:
             raise ValueError('Trying to change network type at runtime')
 
-    if network not in networks:
+    if network not in NETWORKS:
         raise ValueError('Unknown network type: {}'.format(network))
 
-    MAINNET = (network == 'mainnet')
-    NETNAME = network
+    NETWORK = network
     STRICT = strict
 
     return prev_state
 
 
 def get_state():
-    global MAINNET, NETNAME, STRICT
-    return {'netname': NETNAME,
-            'mainnet': MAINNET,
+    global NETWORK, STRICT
+    return {'network': NETWORK,
             'strict': STRICT}
 
 
@@ -58,17 +67,3 @@ def is_strict():
     if STRICT is None:
         ValueError('Strictness not set')
     return STRICT
-
-
-def is_mainnet():
-    global MAINNET
-    if MAINNET is None:
-        raise ValueError('Network type not set')
-    return MAINNET
-
-
-def net_name():
-    global NETNAME
-    if NETNAME is None:
-        raise ValueError('Network type not set')
-    return NETNAME

--- a/btcpy/structs/crypto.py
+++ b/btcpy/structs/crypto.py
@@ -10,17 +10,16 @@
 # LICENSE.md file.
 
 from binascii import unhexlify
-from ..lib.base58 import b58decode_check, b58encode_check
 from hashlib import sha256
 from ecdsa import SigningKey, SECP256k1
 from ecdsa.util import sigencode_der
 from functools import partial
 from abc import ABCMeta
 
-from ..lib.types import HexSerializable
-from .address import P2pkhAddress, P2wpkhAddress
-from ..setup import is_mainnet, net_name, strictness
-from ..constants import Constants
+from btcpy.lib.base58 import b58decode_check, b58encode_check
+from btcpy.lib.types import HexSerializable
+from btcpy.setup import get_state
+from btcpy.structs.address import P2pkhAddress, P2wpkhAddress
 
 
 class WrongPubKeyFormat(Exception):
@@ -40,8 +39,7 @@ class PrivateKey(Key):
     highest_s = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0
 
     @staticmethod
-    @strictness
-    def from_wif(wif, strict=None):
+    def from_wif(wif):
 
         if not 51 <= len(wif) <= 52:
             raise ValueError('Invalid wif length: {}'.format(len(wif)))
@@ -49,12 +47,8 @@ class PrivateKey(Key):
         decoded = b58decode_check(wif)
         prefix, *rest = decoded
 
-        if prefix not in Constants.get('wif.prefixes').values():
+        if prefix != get_state()['network'].wif_prefix:
             raise ValueError('Unknown private key prefix: {:02x}'.format(prefix))
-
-        if strict:
-            if prefix != Constants.get('wif.prefixes')['mainnet' if is_mainnet() else 'testnet']:
-                raise ValueError('{0} prefix in non-{0} environment'.format(net_name()))
 
         public_compressed = len(rest) == 33
         privk = rest[0:32]
@@ -69,10 +63,8 @@ class PrivateKey(Key):
         self.key = priv
         self.public_compressed = public_compressed
 
-    def to_wif(self, mainnet=None):
-        if mainnet is None:
-            mainnet = is_mainnet()
-        prefix = Constants.get('wif.prefixes')['mainnet' if mainnet else 'testnet']
+    def to_wif(self):
+        prefix = get_state()['network'].wif_prefix
         decoded = bytearray([prefix]) + self.key
         if self.public_compressed:
             decoded.append(0x01)
@@ -214,19 +206,15 @@ class PublicKey(BasePublicKey):
     def serialize(self):
         return self.uncompressed if self.type == 'uncompressed' else self.compressed
 
-    def to_address(self, mainnet=None):
-        if mainnet is None:
-            mainnet = is_mainnet()
-        return P2pkhAddress(self.hash(), mainnet)
+    def to_address(self):
+        return P2pkhAddress(self.hash())
 
-    def to_segwit_address(self, version, mainnet=None):
-        if mainnet is None:
-            mainnet = is_mainnet()
+    def to_segwit_address(self, version):
         if self.type == 'uncompressed':
             pubk = PublicKey(self.compressed)
         else:
             pubk = self
-        return P2wpkhAddress(pubk.hash(), version, mainnet)
+        return P2wpkhAddress(pubk.hash(), version)
 
     def __eq__(self, other):
         return (self.type, self.compressed, self.uncompressed) == (other.type, other.compressed, other.uncompressed)

--- a/btcpy/structs/script.py
+++ b/btcpy/structs/script.py
@@ -496,8 +496,8 @@ class P2pkhScript(ScriptPubKey):
     def type(self):
         return 'p2pkh'
 
-    def address(self, mainnet=None):
-        return P2pkhAddress.from_script(self, mainnet)
+    def address(self):
+        return P2pkhAddress.from_script(self)
 
     def is_standard(self):
         return True
@@ -520,8 +520,8 @@ class P2wpkhScript(P2pkhScript, SegWitScript, metaclass=ABCMeta):
                 return cls
         raise ValueError('Undefined version: {}'.format(segwit_version))
 
-    def address(self, mainnet=None):
-        return P2wpkhAddress.from_script(self, mainnet)
+    def address(self):
+        return P2wpkhAddress.from_script(self)
 
 
 class P2wpkhV0Script(P2wpkhScript):
@@ -593,8 +593,8 @@ class P2shScript(ScriptPubKey):
     def is_standard(self):
         return True
 
-    def address(self, mainnet=None):
-        return P2shAddress.from_script(self, mainnet)
+    def address(self):
+        return P2shAddress.from_script(self)
 
 
 class P2wshScript(P2shScript, SegWitScript, metaclass=ABCMeta):
@@ -606,8 +606,8 @@ class P2wshScript(P2shScript, SegWitScript, metaclass=ABCMeta):
                 return cls
         raise ValueError('Undefined version: {}'.format(segwit_version))
 
-    def address(self, mainnet=None):
-        return P2wshAddress.from_script(self, mainnet)
+    def address(self):
+        return P2wshAddress.from_script(self)
 
 
 # noinspection PyUnresolvedReferences

--- a/btcpy/structs/sig.py
+++ b/btcpy/structs/sig.py
@@ -12,11 +12,8 @@
 from enum import Enum
 from abc import ABCMeta, abstractmethod
 
-from ..lib.types import Immutable, HexSerializable
-from .script import (Script, P2shScript, ScriptSig, P2pkhScript, P2wpkhV0Script, P2wshV0Script,
-                     P2pkScript, MultisigScript, TimelockScript, RelativeTimelockScript,
-                     IfElseScript, HashlockScript, StackData)
-from ..lib.parsing import Stream
+from btcpy.lib.types import Immutable, HexSerializable
+from btcpy.structs.script import ScriptSig, StackData
 
 
 class Branch(Enum):

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -13,6 +13,12 @@
 import unittest
 from unittest.mock import patch
 
+from btcpy.constants import (
+    BitcoinMainnet,
+    BitcoinTestnet,
+    PeercoinMainnet,
+    PeercoinTestnet,
+)
 from btcpy.structs.transaction import *
 from btcpy.structs.script import *
 from btcpy.structs.block import *
@@ -25,7 +31,7 @@ from btcpy.lib.base58 import b58decode, b58encode
 from btcpy.lib.base58 import b58decode_check, b58encode_check
 from btcpy.lib.parsing import IncompleteParsingException
 
-setup('regtest')
+setup()
 
 
 def get_data(filename):
@@ -59,6 +65,17 @@ wif = get_data('wif')
 p2wpkh_over_p2sh = get_data("p2wpkh_over_p2sh")
 p2wsh_over_p2sh = get_data("p2wsh_over_p2sh")
 serialization_data = get_data('stack_data/serialization')
+
+
+class RestoreStateTestCase(unittest.TestCase):
+    """TestCase super class that provides setUp and tearDown methods to capture
+    and restore the global state of the system.
+    """
+    def setUp(self):
+        self.prev_state = get_state()
+
+    def tearDown(self):
+        setup(self.prev_state['network'], self.prev_state['strict'], True)
 
 
 class TestB58(unittest.TestCase):
@@ -99,14 +116,20 @@ class TestUnknownScript(unittest.TestCase):
             self.assertEqual(str(result), script['asm'])
 
 
-class TestPrivPubHashAddrP2pkhSegwit(unittest.TestCase):
+class TestPrivPubHashAddrP2pkhSegwit(RestoreStateTestCase):
 
     def test(self):
         for data in priv_pub_hash_addr_p2pkh_segwit:
-            priv = PrivateKey.from_wif(data['privkey'])
+            try:
+                setup(BitcoinMainnet, True, True)
+                priv = PrivateKey.from_wif(data['privkey'])
+            except ValueError:
+                setup(BitcoinTestnet, True, True)
+                priv = PrivateKey.from_wif(data['privkey'])
+
             pub = PublicKey.unhexlify(data['pubkey'])
             pubhash = bytearray(unhexlify(data['pubkeyhash']))
-            address = Address.from_string(data['address'], strict=False)
+            address = Address.from_string(data['address'])
             p2pkhhex = data['scriptpubkey']
             segwit_addr = data['segwit']
 
@@ -137,20 +160,20 @@ class TestHD(unittest.TestCase):
     def test_hd(self):
         masterpriv = None
         for data in hd_keys:
-            priv = ExtendedKey.decode(data['prv'], strict=False)
-            pub = ExtendedKey.decode(data['pub'], strict=False)
+            priv = ExtendedKey.decode(data['prv'])
+            pub = ExtendedKey.decode(data['pub'])
             if data['path'] == 'm':
                 masterpriv = priv
-            self.assertEqual(priv.pub().encode(mainnet=True), pub.encode(mainnet=True))
-            self.assertEqual(priv.encode(mainnet=True), data['prv'])
-            self.assertEqual(pub.encode(mainnet=True), data['pub'])
+            self.assertEqual(priv.pub().encode(), pub.encode())
+            self.assertEqual(priv.encode(), data['prv'])
+            self.assertEqual(pub.encode(), data['pub'])
             derived = masterpriv.derive(data['path'])
-            self.assertEqual(derived.encode(mainnet=True), data['prv'])
-            self.assertEqual(derived.pub().encode(mainnet=True), data['pub'])
+            self.assertEqual(derived.encode(), data['prv'])
+            self.assertEqual(derived.pub().encode(), data['pub'])
 
     def test_priv_pub(self):
-        masterpub = ExtendedPublicKey.decode(hd_keys[0]['pub'], strict=False)
-        masterpriv = ExtendedPublicKey.decode(hd_keys[0]['prv'], strict=False)
+        masterpub = ExtendedPublicKey.decode(hd_keys[0]['pub'])
+        masterpriv = ExtendedPublicKey.decode(hd_keys[0]['prv'])
         pubs = [masterpub]
         privs = [masterpriv]
         paths = ['m/0/1/2147483646/2',
@@ -251,11 +274,17 @@ class TestTransaction(unittest.TestCase):
             self.assertEqual(parsed_script.type, value['type'])
 
 
-class TestSegWitAddress(unittest.TestCase):
+class TestSegWitAddress(RestoreStateTestCase):
 
     def test_valid(self):
         for data in segwit_valid_addresses:
-            address = SegWitAddress.from_string(data['address'], strict=False)
+            try:
+                setup(BitcoinMainnet, True, True)
+                address = SegWitAddress.from_string(data['address'])
+            except CouldNotDecode:
+                setup(BitcoinTestnet, True, True)
+                address = SegWitAddress.from_string(data['address'])
+
             script = ScriptBuilder.identify(data['script'])
             self.assertEqual(address.hash, script.address().hash)
             if len(data['script']) == 44:
@@ -266,7 +295,7 @@ class TestSegWitAddress(unittest.TestCase):
     def test_invalid(self):
         for address in segwit_invalid_addresses:
             with self.assertRaises(CouldNotDecode):
-                print(SegWitAddress.from_string(address, strict=False))
+                print(SegWitAddress.from_string(address))
 
 
 class TestSegwitOverP2sh(unittest.TestCase):
@@ -274,9 +303,7 @@ class TestSegwitOverP2sh(unittest.TestCase):
     def test_p2wpkh_over_p2sh(self):
         for spend in p2wpkh_over_p2sh:
             pubkey = PublicKey.unhexlify(spend['pubkey'])
-            self.assertEqual(str(P2shAddress.from_script(P2wpkhScript.get(spend['witness_version'])(pubkey),
-                                                         mainnet=True)),
-                             spend['address'])
+            self.assertEqual(str(P2shAddress.from_script(P2wpkhScript.get(spend['witness_version'])(pubkey),)), spend['address'])
             self.assertEqual(P2wpkhScript.get(spend['witness_version'])(pubkey).hexlify(), spend['redeem_script'])
             self.assertEqual(str(P2shScript(P2wpkhScript.get(spend['witness_version'])(pubkey))), spend['script_pubkey'])
 
@@ -285,9 +312,7 @@ class TestSegwitOverP2sh(unittest.TestCase):
             wit_script = ScriptBuilder.identify(spend['witness_script'])
             self.assertEqual(str(P2shScript(P2wshScript.get(spend['witness_version'])(wit_script))), spend['script_pubkey'])
             self.assertEqual(P2wshScript.get(spend['witness_version'])(wit_script).hexlify(), spend['redeem_script'])
-            self.assertEqual(str(P2shAddress.from_script(P2wshScript.get(spend['witness_version'])(wit_script),
-                                                         mainnet=True)),
-                             spend['address'])
+            self.assertEqual(str(P2shAddress.from_script(P2wshScript.get(spend['witness_version'])(wit_script))), spend['address'])
 
 
 class TestReplace(unittest.TestCase):
@@ -365,14 +390,18 @@ class TestStackData(unittest.TestCase):
             self.assertTrue(int(StackData.from_int(x)) == x)
 
 
-class TestKeys(unittest.TestCase):
+class TestKeys(RestoreStateTestCase):
+
+    def setUp(self):
+        super().setUp()
+        setup(BitcoinTestnet, True, True)
 
     def test_priv_to_pubhash(self):
         for priv, addr, _ in privk['derivations']:
-            self.assertEqual(str(PrivateKey.from_wif(priv).pub().to_address(mainnet=False)),
-                             addr)
+            
+            self.assertEqual(str(PrivateKey.from_wif(priv).pub().to_address()), addr)
             self.assertEqual(PrivateKey.from_wif(priv).pub().hash(),
-                             Address.from_string(addr, strict=False).hash)
+                             Address.from_string(addr).hash)
 
     def test_derivation(self):
         m = ExtendedPrivateKey.decode(privk['master'])
@@ -381,11 +410,17 @@ class TestKeys(unittest.TestCase):
 
     def test_to_wif(self):
         for w in wif:
-            self.assertEqual(PrivateKey.from_wif(w['wif'], strict=False).hexlify(), w['hex'])
+            try:
+                setup(BitcoinMainnet, True, True)        
+                self.assertEqual(PrivateKey.from_wif(w['wif']).hexlify(), w['hex'])
+            except:
+                setup(BitcoinTestnet, True, True)        
+                self.assertEqual(PrivateKey.from_wif(w['wif']).hexlify(), w['hex'])
+
             priv = PrivateKey.unhexlify(w['hex'])
             if not w['compressed']:
                 priv.public_compressed = False
-            self.assertEqual(priv.to_wif(w['mainnet']), w['wif'])
+            self.assertEqual(priv.to_wif(), w['wif'])
 
 
 class TestPubkey(unittest.TestCase):
@@ -407,21 +442,47 @@ class TestPubkey(unittest.TestCase):
 
     def test_address_generation(self):
         pubk = PublicKey.unhexlify(self.uncompressed)
-        self.assertTrue(str(pubk.to_address(True)) == self.address)
+        self.assertTrue(str(pubk.to_address()) == self.address)
 
 
-class TestPrivKey(unittest.TestCase):
+class TestPrivKey(RestoreStateTestCase):
 
-    def __init__(self, *args, **kwargs):
+    def setUp(self):
+        super().setUp()
         from ecdsa import SigningKey, SECP256k1
-        super().__init__(*args, **kwargs)
-        self.privs = [ExtendedPrivateKey.decode(k[1], strict=False).key for k in keys]
-        self.vers = [SigningKey.from_string(p.key, curve=SECP256k1).get_verifying_key() for p in self.privs]
+
+        self.mainnet_privs = []
+        self.testnet_privs = []
+        self.mainnet_vers = []
+        self.testne_vers = []
+
+        for k in keys:
+            try:
+                setup(BitcoinMainnet, True, True)
+                self.mainnet_privs.append(ExtendedPrivateKey.decode(k[1]).key)
+            except ValueError:
+                setup(BitcoinTestnet, True, True)
+                self.testnet_privs.append(ExtendedPrivateKey.decode(k[1]).key)
+
+        setup(BitcoinMainnet, True, True)
+        self.mainnet_vers = [SigningKey.from_string(p.key, curve=SECP256k1).get_verifying_key() for p in self.mainnet_privs]
+
+        setup(BitcoinTestnet, True, True)
+        self.testnet_vers = [SigningKey.from_string(p.key, curve=SECP256k1).get_verifying_key() for p in self.testnet_privs]
 
     def test_raw_sig_success(self):
         from os import urandom
         for _ in range(10):
-            for ver, priv in zip(self.vers, self.privs):
+
+            setup(BitcoinMainnet, True, True)
+            for ver, priv in zip(self.mainnet_vers, self.mainnet_privs):
+                digest = bytearray(urandom(32))
+                r, s, order = priv.raw_sign(digest)
+                self.assertTrue(s in range(1, PrivateKey.highest_s))
+                self.assertTrue(ver.verify_digest((r, s), digest, sigdecode=lambda sig, _: (sig[0], sig[1])))
+
+            setup(BitcoinTestnet, True, True)
+            for ver, priv in zip(self.testnet_vers, self.testnet_privs):
                 digest = bytearray(urandom(32))
                 r, s, order = priv.raw_sign(digest)
                 self.assertTrue(s in range(1, PrivateKey.highest_s))
@@ -430,8 +491,11 @@ class TestPrivKey(unittest.TestCase):
     def test_der_sig_success(self):
         from os import urandom
         import struct
+
         for _ in range(10):
-            for priv in self.privs:
+
+            setup(BitcoinMainnet, True, True)
+            for priv in self.mainnet_privs:
                 digest = bytearray(urandom(32))
                 sig = priv.sign(digest)
                 length_r = sig[3]
@@ -439,10 +503,26 @@ class TestPrivKey(unittest.TestCase):
                 s = int.from_bytes(bytearray(struct.unpack(str(length_s) + 'B', sig[6 + length_r:6 + length_r + length_s])), 'big')
                 self.assertTrue(s in range(1, PrivateKey.highest_s))
 
+            setup(BitcoinTestnet, True, True)
+            for priv in self.testnet_privs:
+                digest = bytearray(urandom(32))
+                sig = priv.sign(digest)
+                length_r = sig[3]
+                length_s = sig[5 + length_r]
+                s = int.from_bytes(bytearray(struct.unpack(str(length_s) + 'B', sig[6 + length_r:6 + length_r + length_s])), 'big')
+                self.assertTrue(s in range(1, PrivateKey.highest_s))
+
+
     def test_derivation_success(self):
         for pub, priv in keys:
-            pu = ExtendedPublicKey.decode(pub, strict=False).key
-            pr = ExtendedPrivateKey.decode(priv, strict=False).key
+            try:
+                setup(BitcoinMainnet, True, True)
+                pu = ExtendedPublicKey.decode(pub).key
+            except ValueError:
+                setup(BitcoinTestnet, True, True)
+                pu = ExtendedPublicKey.decode(pub).key
+
+            pr = ExtendedPrivateKey.decode(priv).key
             self.assertTrue(pr.pub() == pu)
             self.assertTrue(pr.pub().hexlify() == pu.hexlify())
 
@@ -475,10 +555,11 @@ class TestP2pk(unittest.TestCase):
             P2pkScript.unhexlify('21{}ad'.format(self.pubk))
 
 
-class TestP2pkh(unittest.TestCase):
+class TestP2pkh(RestoreStateTestCase):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
+        super().setUp()
+        setup(BitcoinTestnet, True, True)
         self.pubk = PublicKey.unhexlify('0384478d41e71dc6c3f9edde0f928a47d1b724c05984ebfb4e7d0422e80abe95ff')
         self.pubkh = self.pubk.hash()
         self.address = Address.from_string('mquvJWnJJwTDUcdneQkUbrfN2wm9uiXd1p')
@@ -554,7 +635,7 @@ class TestPwpkhScript(unittest.TestCase):
             P2wpkhV0Script.unhexlify('0114{}'.format(hexlify(self.pubkh).decode()))
 
 
-class TestP2sh(unittest.TestCase):
+class TestP2sh(RestoreStateTestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -580,7 +661,13 @@ class TestP2sh(unittest.TestCase):
 
         for script_hex, address in p2sh.items():
             script = ScriptBuilder.identify(bytearray(unhexlify(script_hex)))
-            from_addr = P2shScript(Address.from_string(address))
+            try:
+                setup(BitcoinMainnet, True, True)
+                from_addr = P2shScript(Address.from_string(address))
+            except CouldNotDecode:
+                setup(BitcoinTestnet, True, True)
+                from_addr = P2shScript(Address.from_string(address))
+
             from_script = P2shScript(script)
             self.assertTrue(str(from_addr.address()) == address)
             self.assertTrue(str(P2shAddress.from_script(script)) == address)
@@ -814,19 +901,19 @@ class TestHashlock(unittest.TestCase):
                                                                 self.locked_script.hexlify()))
 
 
-class TestBitcoinAddress(unittest.TestCase):
+class TestBitcoinAddress(RestoreStateTestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.good_addresses = {('mainnet', P2pkhAddress, '1KKKK6N21XKo48zWKuQKXdvSsCf95ibHFa',
+        self.good_addresses = {('BitcoinMainnet', P2pkhAddress, '1KKKK6N21XKo48zWKuQKXdvSsCf95ibHFa',
                                 b'\xc8\xe9\t\x96\xc7\xc6\x08\x0e\xe0b\x84`\x0chN\xd9\x04\xd1L\\'),
-                               ('testnet', P2pkhAddress, 'mtH6FLMQNu2fFQ4mrb7UjEUjTAhUNCMFoi',
+                               ('BitcoinTestnet', P2pkhAddress, 'mtH6FLMQNu2fFQ4mrb7UjEUjTAhUNCMFoi',
                                 b'\x8b\xfas]\x98\xabb\x1e\xdbOw\xd7\xb7\xfe\nK\x1f\xfc\xc0$'),
-                               ('testnet', P2pkhAddress, 'n3wEvhujG7SDcgeKCXZMrty5QqhQZ7f6jW',
+                               ('BitcoinTestnet', P2pkhAddress, 'n3wEvhujG7SDcgeKCXZMrty5QqhQZ7f6jW',
                                 b'\xf5\xea\xa2K\x82\xc8\x1f4L\x9a\x16\xa8\xfb\x84t\xe1\x10\xfd\xb1\xc3'),
-                               ('mainnet', P2shAddress, '3P14159f73E4gFr7JterCCQh9QjiTjiZrG',
+                               ('BitcoinMainnet', P2shAddress, '3P14159f73E4gFr7JterCCQh9QjiTjiZrG',
                                 b'\xe9\xc3\xdd\x0c\x07\xaa\xc7ay\xeb\xc7jlx\xd4\xd6|l\x16\n'),
-                               ('testnet', P2shAddress, '2N6JFaB5rMtPwutovP6cirwBVxHuAVaHvMG',
+                               ('BitcoinTestnet', P2shAddress, '2N6JFaB5rMtPwutovP6cirwBVxHuAVaHvMG',
                                 b'\x8f,4\xa2<F\xe9\x80\xb7\x9e\x10\x9b\x11\xa2\xc8-9\x92\xeb\x95')}
         self.bad_addresses = {'vioqwV3F4YzpgnfyUukGVMB3Hv83ujehKCiGWyrYyx2Z7hiKQy7SWUV9KgfMdV9J',
                               'bc1a',
@@ -835,35 +922,40 @@ class TestBitcoinAddress(unittest.TestCase):
 
     def test_success(self):
         for net, addr_type, address, hashed_data in self.good_addresses:
-            from_string = Address.from_string(address, strict=False)
+            if net == "BitcoinMainnet":
+                setup(BitcoinMainnet, True, True)
+            else:
+                setup(BitcoinTestnet, True, True)
+            from_string = Address.from_string(address)
             self.assertTrue(address == str(from_string))
             self.assertTrue(from_string.__class__ == addr_type)
             self.assertTrue(from_string.network == net)
             self.assertTrue(from_string.hash == hashed_data)
 
     def test_fail(self):
+        setup(BitcoinMainnet, True, True)
         for address in self.bad_addresses:
             with self.assertRaises(ValueError):
-                Address.from_string(address, strict=False)
+                Address.from_string(address)
 
     def test_conversions(self):
         for address, pkh in addresses:
-            self.assertEqual(hexlify(Address.from_string(address, strict=False).hash).decode(), pkh)
-            self.assertEqual(str(P2pkhScript(bytearray(unhexlify(pkh))).address(mainnet=True)), address)
-            self.assertEqual(P2pkhScript(Address.from_string(address, strict=False)).pubkeyhash,
+            self.assertEqual(hexlify(Address.from_string(address).hash).decode(), pkh)
+            self.assertEqual(str(P2pkhScript(bytearray(unhexlify(pkh))).address()), address)
+            self.assertEqual(P2pkhScript(Address.from_string(address)).pubkeyhash,
                              bytearray(unhexlify(pkh)))
-            self.assertEqual(P2pkhAddress(bytearray(unhexlify(pkh)), mainnet=True).hash, bytearray(unhexlify(pkh)))
+            self.assertEqual(P2pkhAddress(bytearray(unhexlify(pkh))).hash, bytearray(unhexlify(pkh)))
 
 
-class TestPeercoinAddress(unittest.TestCase):
+class TestPeercoinAddress(RestoreStateTestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.good_addresses = {
-            ('mainnet', P2pkhAddress, 'PAdonateFczhZuKLkKHozrcyMJW7Y6TKvw',),
-            ('testnet', P2pkhAddress, 'mj46gUeZgeD9ufU7Fvz2dWqaX6Nswtbpba',),
-            ('testnet', P2pkhAddress, 'n12h8P5LrVXozfhEQEqg8SFUmVKtphBetj',),
-            ('mainnet', P2shAddress, 'p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK',),
+            ('PeercoinMainnet', P2pkhAddress, 'PAdonateFczhZuKLkKHozrcyMJW7Y6TKvw',),
+            ('PeercoinTestnet', P2pkhAddress, 'mj46gUeZgeD9ufU7Fvz2dWqaX6Nswtbpba',),
+            ('PeercoinTestnet', P2pkhAddress, 'n12h8P5LrVXozfhEQEqg8SFUmVKtphBetj',),
+            ('PeercoinMainnet', P2shAddress, 'p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK',),
         }
         self.bad_addresses = {
             'vioqwV3F4YzpgnfyUukGVMB3Hv83ujehKCiGWyrYyx2Z7hiKQy7SWUV9KgfMdV9J',
@@ -873,16 +965,24 @@ class TestPeercoinAddress(unittest.TestCase):
         }
 
     def test_success(self):
+
         for net, addr_type, address in self.good_addresses:
-            from_string = Address.from_string(address, strict=False)
+            if net == 'PeercoinMainnet':
+                setup(PeercoinMainnet, True, True)
+            else:
+                setup(PeercoinTestnet, True, True)
+
+            from_string = Address.from_string(address)
             self.assertTrue(address == str(from_string))
             self.assertTrue(from_string.__class__ == addr_type)
             self.assertTrue(from_string.network == net)
 
     def test_fail(self):
+        setup(PeercoinMainnet, True, True)
+
         for address in self.bad_addresses:
             with self.assertRaises(ValueError):
-                Address.from_string(address, strict=False)
+                Address.from_string(address)
 
 
 class TestStandardness(unittest.TestCase):
@@ -1058,17 +1158,10 @@ class TestSegwitSigs(unittest.TestCase):
                                          tx['signature'])
 
 
-class TestStrictMode(unittest.TestCase):
-
-    def setUp(self):
-        from btcpy.setup import get_state
-        self.prev_setup = get_state()
-
-    def tearDown(self):
-        setup(self.prev_setup['netname'], strict=self.prev_setup['strict'], force=True)
+class TestStrictMode(RestoreStateTestCase):
 
     def test_multisig_parsing_non_strict(self):
-        setup(self.prev_setup['netname'], strict=False, force=True)
+        setup(BitcoinMainnet, strict=False, force=True)
 
         # 1 of 2 with one valid and one invalid public key
         script_hex = ('5121037953dbf08030f67352134992643d033417eaa6fcfb770c038f364ff40d7615882100e8f87dd9d24c3a2f1'
@@ -1098,7 +1191,7 @@ class TestStrictMode(unittest.TestCase):
         self.assertTrue(isinstance(script.pubkeys[1], StackData))
 
     def test_multisig_parsing_strict(self):
-        setup(self.prev_setup['netname'], strict=True, force=True)
+        setup(BitcoinMainnet, strict=True, force=True)
 
         # 1 of 2 with one valid and one invalid public key
         script_hex = ('5121037953dbf08030f67352134992643d033417eaa6fcfb770c038f364ff40d7615882100e8f87dd9d24c3a2f1'
@@ -1124,7 +1217,7 @@ class TestStrictMode(unittest.TestCase):
             MultisigScript(script)
 
     def test_multisig_creation_strict(self):
-        setup(self.prev_setup['netname'], strict=True, force=True)
+        setup(BitcoinMainnet, strict=True, force=True)
         with self.assertRaises(WrongPubKeyFormat):
             MultisigScript(1, StackData.unhexlify('00'*33), StackData.unhexlify('00'*33), 2)
 
@@ -1138,7 +1231,7 @@ class TestStrictMode(unittest.TestCase):
         self.assertTrue(isinstance(script.pubkeys[1], PublicKey))
 
     def test_multisig_creation_non_strict(self):
-        setup(self.prev_setup['netname'], strict=False, force=True)
+        setup(BitcoinMainnet, strict=False, force=True)
 
         script = MultisigScript(1, StackData.unhexlify('00'*33), StackData.unhexlify('00'*33), 2)
         self.assertTrue(isinstance(script, MultisigScript))
@@ -1159,7 +1252,7 @@ class TestStrictMode(unittest.TestCase):
             MultisigScript(1, StackData.unhexlify('00'*2), StackData.unhexlify('00'*33), 2)
 
     def test_p2pk_parsing_non_strict(self):
-        setup(self.prev_setup['netname'], strict=False, force=True)
+        setup(BitcoinMainnet, strict=False, force=True)
         script_hex = '2100e8f87dd9d24c3a2f102a5a8276c4a8f58176c961dada423b61063a312b7c270eac'
         script = ScriptBuilder.identify(script_hex)
         self.assertTrue(isinstance(script, P2pkScript))
@@ -1167,19 +1260,19 @@ class TestStrictMode(unittest.TestCase):
         self.assertTrue(isinstance(script.pubkey, StackData))
 
     def test_p2pk_parsing_strict(self):
-        setup(self.prev_setup['netname'], strict=True, force=True)
+        setup(BitcoinMainnet, strict=True, force=True)
         script_hex = '2100e8f87dd9d24c3a2f102a5a8276c4a8f58176c961dada423b61063a312b7c270eac'
         script = Script.unhexlify(script_hex)
         with self.assertRaises(WrongPubKeyFormat):
             P2pkScript(script)
 
     def test_p2pk_creation_strict(self):
-        setup(self.prev_setup['netname'], strict=True, force=True)
+        setup(BitcoinMainnet, strict=True, force=True)
         with self.assertRaises(TypeError):
             P2pkScript(StackData.unhexlify('00'*33))
 
     def test_p2pk_creation_non_strict(self):
-        setup(self.prev_setup['netname'], strict=False, force=True)
+        setup(BitcoinMainnet, strict=False, force=True)
         script = P2pkScript(StackData.unhexlify('00'*33))
         self.assertTrue(isinstance(script, P2pkScript))
         self.assertEqual(script.type, 'p2pk')
@@ -1187,9 +1280,6 @@ class TestStrictMode(unittest.TestCase):
 
         with self.assertRaises(WrongScriptTypeException):
             P2pkScript(StackData.unhexlify('00'*30))
-
-
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@peerchemist @saeveritt :wave: 

I tried to focus on just the namedtuple constants in this pull request. This is actually a `git cherry-pick` of work done on the most recent chainside master: https://github.com/chainside/btcpy/compare/master...belovachap:chainside_namedtuples_in_constants?expand=1 :rainbow: 

By pulling the constants apart into Testnet and Mainnet a lot of the `strict` rules were being inherently enforced so I pulled some of those extraneous function parameters out. I also didn't end up passing `mainnet` into many constructors so I removed those as well. Although, in Part II, when we relax the dependency on the global state (i.e. stop using `get_state()`) we'll likely be passing network constants into objects which might have a similar "feel" but slightly different function :four_leaf_clover: :fountain: :fountain_pen: 