### PR TITLE
Improved transaction unhexilify.

### DIFF
--- a/btcpy/lib/parsing.py
+++ b/btcpy/lib/parsing.py
@@ -298,7 +298,7 @@ class PeercoinTxParser(TransactionParser):
         if segwit:
             raise Exception('Peercoin does not currently support SegWit.')
         else:
-            result = PeercoinTx(version, tstamp, txins, txouts, locktime)
+            result = PeercoinTx(version, tstamp, txins, txouts, locktime, self.network)
 
         return result.to_mutable() if mutable else result
 

--- a/btcpy/structs/transaction.py
+++ b/btcpy/structs/transaction.py
@@ -16,8 +16,8 @@ from .sig import Sighash
 from .script import (ScriptBuilder, P2wpkhV0Script, P2wshV0Script, P2shScript, NulldataScript, ScriptSig,
                      CoinBaseScriptSig, ScriptPubKey)
 from ..lib.types import Immutable, Mutable, Jsonizable, HexSerializable, cached
-from ..lib.parsing import Parser, TransactionParser, Stream
-from btcpy.constants import BitcoinMainnet
+from ..lib.parsing import Parser, PeercoinTxParser, TransactionParser, Stream
+from btcpy.constants import BitcoinMainnet, PeercoinMainnet
 
 
 # noinspection PyUnresolvedReferences
@@ -367,8 +367,8 @@ class Transaction(Immutable, HexSerializable, Jsonizable):
     max_weight = 400000
 
     @classmethod
-    def unhexlify(cls, string, tx_parser=TransactionParser, network=BitcoinMainnet):
-        return cls.deserialize(bytearray(unhexlify(string)), tx_parser, network)
+    def unhexlify(cls, string, network=BitcoinMainnet):
+        return cls.deserialize(bytearray(unhexlify(string)), TransactionParser, network)
 
     @classmethod
     def deserialize(cls, string, tx_parser, network):
@@ -582,6 +582,10 @@ class PeercoinTx(Transaction):
 
         if txid != self.txid and txid is not None:
             raise ValueError('txid {} does not match transaction data {}'.format(txid, self.hexlify()))
+
+    @classmethod
+    def unhexlify(cls, string, network=PeercoinMainnet):
+        return cls.deserialize(bytearray(unhexlify(string)), PeercoinTxParser, network)
 
     @classmethod
     def from_json(cls, tx_json, network):

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -954,6 +954,21 @@ class TestPeercoinAddress(unittest.TestCase):
                 Address.from_string(PeercoinMainnet, address)
 
 
+class TestPeercoinTx(unittest.TestCase):
+
+    def test_unhexilify(self):
+        """Check that we can parse a PeercoinTx from hex encoded bytes. Data from:
+
+        In [1]: import pypeerassets as pa
+
+        In [2]: provider = pa.Explorer(network='tppc')
+
+        In [3]: raw = provider.getrawtransaction('c418f3bded92ebc035cfefc93f54dc8a501702e6ad4e6a26a07aab87f4cfb653')
+        """
+        raw = '01000000f7ae3b5b01b3a00d828f5a9a8e908fb59353b4a87132a75a6d939c6e9338e3727631a65028010000006c493046022100e3a72a3a9f53eab66186da5354a58a6fb4b4fc96c5836445bce0b3755840653f022100f7013eb0c3bbd901a8e9c4935edefa9765fa5dd2f1f3a276634d248a4e17c59801210207c75090d56b94a9f638b8b9abaa346c053db265f4aa752170b86c32cdec7efbffffffff0260d3e815000000001976a914c8ec65800888c2c4f831826ba7e10603b3692db188ac00e1f505000000001976a914ba96e0c304ad07afb115d7019b9e54db96668f9988ac00000000'
+        PeercoinTx.unhexlify(raw, network=PeercoinTestnet)
+
+
 class TestStandardness(unittest.TestCase):
 
     def test_script_pubkey_success(self):


### PR DESCRIPTION
@peerchemist 

Removed the parser from the function parameters since it didn't need to be a variable. Added a test for the functionality you were describing in #10 (and it uncovered a :bug: !). Seems like the `unhexlify` function is a bit nicer now :rainbow: :1st_place_medal: :money_with_wings: 