### PR TITLE
Add .travis.yml to run unit tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 build/
 *.egg-info/
 .mypy_cache
+venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "3.5"
+  - "3.6"
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+# command to run tests
+script:
+  - python -m unittest tests.unit
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # peerassets-btcpy
 
+[![Build Status](https://travis-ci.org/PeerAssets/btcpy.svg?branch=master)](https://travis-ci.org/PeerAssets/btcpy)
+
 `btcpy` is a Python3 SegWit-compliant library which provides tools to handle
 Bitcoin data structures in a simple fashion. In particular, the main goal of
 this library is to provide a simple interface to parse and create complex


### PR DESCRIPTION
@peerchemist :wave: 

Here's a start for #12 :) You'll need to log into https://travis-ci.org/ and enable `PeerAssets/btcpy`.

The build is currently failing because of https://github.com/chainside/btcpy/pull/42 ... but maybe that just means it's time to go fix that upstream bug :bug: :rainbow: :fountain: :four_leaf_clover: 